### PR TITLE
Check if the draft is valid before adding it to $autopublishedDrafts

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
             $autopublishfield = option("bvdputte.kirbyAutopublish.fieldName");
             $drafts = $site->pages()->drafts();
             $autoPublishedDrafts = $drafts->filter(function ($draft) use ($autopublishfield) {
-                return ($draft->$autopublishfield()->exists()) && (!$draft->$autopublishfield()->isEmpty());
+                return ($draft->$autopublishfield()->exists()) && (!$draft->$autopublishfield()->isEmpty()) && (empty($draft->errors()) === true);
             });
 
             return $autoPublishedDrafts;


### PR DESCRIPTION
Try to create an invalid draft (in my case, an unfilled image section with `min: 1`) and set an autopublish date.
Broke the whole website (+ panel).
This PR prevents this error to be thrown by processing only valid drafts.

This plugin proves very handy! Thank you.