### PR TITLE
make it possible to use a webhook instead of cron

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,8 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
         'fieldName' => 'autopublish',
         'poormanscron' => false,
         'poormanscron.interval' => 1, // in minutes
-        'cache.poormanscron' => true
+        'cache.poormanscron' => true,
+        'webhookToken' => false,
     ],
     'collections' => [
         'autoPublishedDrafts' => function ($site) {
@@ -35,5 +36,19 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
                 bvdputte\kirbyAutopublish\Autopublish::poorManCronRun();
             }
         }
-    ]
+    ],
+    ,
+    'routes' => [
+        [
+            'pattern' => 'kirby-autopublish/(:any)',
+            'action' => function ($token) {
+                if ($token !== option('bvdputte.kirbyAutopublish.webhookToken', false) || option('bvdputte.kirbyAutopublish.webhookToken', false) === false) {
+                    throw new Exception('Invalid token');
+                    return false;
+                }
+
+                bvdputte\kirbyAutopublish\Autopublish::publish();
+                return new Response('done', 'text/html');
+            }
+        ],
 ]);


### PR DESCRIPTION
Some hosters (like mine) do not allow regular cronjobs, but you are able to create a "cron" in their admin panel and configure an url which should be opened in certain intervalls. 

This change will add a route which can be accessed by defining a token in the config.php and then add the url+token as a webhook-url wherever you like.

Introduces:

`kirby-autopublish/TOKEN`

as new route.

`bvdputte.kirbyAutopublish.webhookToken`

as config var for setting a token

