### PR TITLE
feat: add optional toggle to en- or disable the date fields

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,14 +1,18 @@
 <?php
 
-require __DIR__ . DS . "src" . DS . "Autopublish.php";
+use Kirby\Cms\Response;
+
+require __DIR__.DS."src".DS."Autopublish.php";
 
 // For composer
-@include_once __DIR__ . '/vendor/autoload.php';
+@include_once __DIR__.'/vendor/autoload.php';
 
 Kirby::plugin('bvdputte/kirbyAutopublish', [
     'options' => [
         'fieldName' => 'autopublish',
+        'fieldNameToggle' => 'autopublishtoggle',
         'fieldNameUnpublish' => 'autounpublish',
+        'fieldNameUnpublishToggle' => 'autounpublishtoggle',
         'poormanscron' => false,
         'poormanscron.interval' => 1, // in minutes
         'cache.poormanscron' => true,
@@ -17,19 +21,45 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
     'collections' => [
         'autoPublishedDrafts' => function ($site) {
             $autopublishfield = option("bvdputte.kirbyAutopublish.fieldName");
+            $autopublishfieldtoggle = option("bvdputte.kirbyAutopublish.fieldNameToggle");
             $drafts = $site->index()->drafts();
-            $autoPublishedDrafts = $drafts->filter(function ($draft) use ($autopublishfield) {
-                return ($draft->$autopublishfield()->exists()) && ($draft->$autopublishfield()->isNotEmpty()) && (empty($draft->errors()) === true);
+
+            return $drafts->filter(function ($draft) use ($autopublishfield, $autopublishfieldtoggle) {
+                $hasToggle = $draft->$autopublishfieldtoggle()->exists();
+                $isEnabled = $draft->$autopublishfieldtoggle()->value();
+                $autopublish = $draft->$autopublishfield()->exists() && $draft->$autopublishfield()->isNotEmpty() && empty($draft->errors());
+
+                if (!$hasToggle) {
+                    return $autopublish;
+                }
+
+                if ($isEnabled) {
+                    return $autopublish;
+                }
+
+                return false;
             });
-            return $autoPublishedDrafts;
         },
         'autoUnpublishedListed' => function ($site) {
             $autounpublishfield = option("bvdputte.kirbyAutopublish.fieldNameUnpublish");
+            $autounpublishfieldtoggle = option("bvdputte.kirbyAutopublish.fieldNameUnpublishToggle");
             $listed = $site->index()->children()->listed();
-            $autoUnpublishedListed = $listed->filter(function ($listedPage) use ($autounpublishfield) {
-                return ($listedPage->$autounpublishfield()->exists()) && ($listedPage->$autounpublishfield()->isNotEmpty()) && (empty($listedPage->errors()) === true);
+
+            return $listed->filter(function ($listedPage) use ($autounpublishfield, $autounpublishfieldtoggle) {
+                $hasToggle = $listedPage->$autounpublishfieldtoggle()->exists();
+                $isEnabled = $listedPage->$autounpublishfieldtoggle()->value();
+                $autounpublish = $listedPage->$autounpublishfield()->exists() && $listedPage->$autounpublishfield()->isNotEmpty() && empty($listedPage->errors());
+
+                if (!$hasToggle) {
+                    return $autounpublish;
+                }
+
+                if ($isEnabled) {
+                    return $autounpublish;
+                }
+
+                return false;
             });
-            return $autoUnpublishedListed;
         }
     ],
     'hooks' => [
@@ -52,11 +82,11 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
                     option('bvdputte.kirbyAutopublish.webhookToken', false) === false
                 ) {
                     throw new Exception('Invalid token');
-                    return false;
                 }
 
                 bvdputte\kirbyAutopublish\Autopublish::publish();
                 bvdputte\kirbyAutopublish\Autopublish::unpublish();
+
                 return new Response('done', 'text/html');
             }
         ],

--- a/readme.md
+++ b/readme.md
@@ -49,11 +49,37 @@ Set in `config.php`:
 
 ### Field name
 
-Autopublish searches for a date-field. By default the name is `autopublish` and `autounpublish`, but can be changed:
+Autopublish searches for a date-field. By default, the name is `autopublish` and `autounpublish`, but can be changed:
 
 ```php
 'fieldName' => 'myautopublishfieldname',
 'fieldNameUnpublish' => 'myAutoUnpublishFieldName'
+```
+
+You can connect the above-mentioned date-fields to a [toggle](https://getkirby.com/docs/reference/panel/fields/toggle). This allows you to configure the publish/unpublish behaviour
+without changing the actual date and time values.
+
+```php
+'fieldNameToggle' => 'autopublishtoggle',
+'fieldNameUnpublishToggle' => 'autounpublishtoggle'
+```
+
+#### Example Blueprint
+
+```yaml
+autopublishtoggle:
+    type: toggle
+    label: Autopublish
+    text:
+        - Disabled
+        - Enabled
+autopublish:
+    label: Publish at
+    type: date
+    time: true
+    default: now
+    when:
+        autopublishtoggle: true
 ```
 
 ### Poor man's cron


### PR DESCRIPTION
This MR closes #7 by adding an optional toggle field which allows to enable (or disable) the date fields. It utilizes the [Conditional Field](https://getkirby.com/docs/guide/blueprints/fields#conditional-fields) feature which was introduced with Kirby 3.1.0.

<img width="430" alt="Bildschirmfoto 2021-11-15 um 09 42 31" src="https://user-images.githubusercontent.com/965069/141749834-f0d524bc-425e-42db-aab0-8b9dc5852612.png">
<img width="430" alt="Bildschirmfoto 2021-11-15 um 09 42 37" src="https://user-images.githubusercontent.com/965069/141749842-ef1f0114-ac2f-40ff-8e16-63868f42c341.png">

I adapted the filter callback a bit and added a condition to check wether a toogle exists or not.

If the toogle doesn't exist, the original behaviour is unchanged.
If the toogle exist, the value ('true' or `false`) of that toogle is evaluated. 
If the value is `true` (enabled), the original behaviour kicks in
If the value is `false` (disabled), the filter is unchanged

You can use it in blueprints like so:

```yaml
fields:
  autopublishtoggle:
    type: toggle
    label: Autopublish
    text:
      - Disabled
      - Enabled
  autopublish:
    label: Publish on
    type: date
    time: true
    default: now
    when:
      autopublishtoggle: true
  autounpublishtoggle:
    type: toggle
    label: Autounpublish
    text:
      - Disabled
      - Enabled
  autounpublish:
    label: Unpublish on
    type: date
    time: true
    when:
      autounpublishtoggle: true
```

The actual field names are configurable by setting the proper option in `/site/config.php`

```php
'fieldNameToggle' => 'autopublishtoggle',
'fieldNameUnpublishToggle' => 'autounpublishtoggle'
```