### PR TITLE
feat: add version to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Kirby 3 plugin to schedule the automatic publishing of pages on a certain date+time. It is built to work with enabled cache.",
     "license": "MIT",
     "type": "kirby-plugin",
+    "version": "2.0.0",
     "authors": [
         {
             "name": "Bart Vandeputte",


### PR DESCRIPTION
I would love to have the version-info in your plugins,
so it would be shown in the new Kirby Sytem Informations.
If you add 'version', to the composer.json, it will be shown there.

![grafik](https://user-images.githubusercontent.com/562826/159485490-49b2d2c4-1079-4625-94fb-d01b95bea1d1.png)

Thx!