### PR TITLE
add support for top level pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,6 +18,7 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
         'autoPublishedDrafts' => function ($site) {
             $autopublishfield = option("bvdputte.kirbyAutopublish.fieldName");
             $drafts = $site->index()->drafts();
+            $drafts->add($site->drafts()); //adds top level drafts to collection
             $autoPublishedDrafts = $drafts->filter(function ($draft) use ($autopublishfield) {
                 return ($draft->$autopublishfield()->exists()) && ($draft->$autopublishfield()->isNotEmpty()) && (empty($draft->errors()) === true);
             });
@@ -26,6 +27,7 @@ Kirby::plugin('bvdputte/kirbyAutopublish', [
         'autoUnpublishedListed' => function ($site) {
             $autounpublishfield = option("bvdputte.kirbyAutopublish.fieldNameUnpublish");
             $listed = $site->index()->children()->listed();
+            $listed->add($site->children()->listed()); //adds top level listed pages to collection
             $autoUnpublishedListed = $listed->filter(function ($listedPage) use ($autounpublishfield) {
                 return ($listedPage->$autounpublishfield()->exists()) && ($listedPage->$autounpublishfield()->isNotEmpty()) && (empty($listedPage->errors()) === true);
             });


### PR DESCRIPTION
I needed to use your autopublish plugin for top level pages and therefore added them to the collection of drafts to publish respectively the collection of pages to be unpublished.

I would like to propose adding this feature to your plugin.

If for some reason I didn't think of top level pages are left out for a certain reason, I am happy to edit the code in a way that enables top level pages via an option, for example. Just let me know.

Thanks for the great plugin, it really helped me out.